### PR TITLE
Repository umbenennen

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,4 +40,4 @@ this repository (CC BY-SA 4.0).
 ## Building Stuff
 
 If you want to contribute code to the project, please follow our 
-[code conventions](https://github.com/PM-Dungeon/core/wiki/Code-conventions). 
+[code conventions](https://github.com/Programmiermethoden/PM-Dungeon/wiki/Code-conventions). 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,11 @@
-[![Java CI](https://github.com/PM-Dungeon/core/actions/workflows/github_ci.yml/badge.svg)](https://github.com/PM-Dungeon/core/actions/workflows/github_ci.yml)
+[![Java CI](https://github.com/Programmiermethoden/pm-dungeon/actions/workflows/github_ci.yml/badge.svg)](https://github.com/Programmiermethoden/pm-dungeon/actions/workflows/github_ci.yml)
 
 # PM-Dungeon-Framework
+
 
 ## About
 
 The **PM-Dungeon** is a lightweight Java framework for the development of a 2D-Rouge-like game. It is designed for educational purposes and is especially aimed at inexperienced Java developers. The project currently uses the [libGDX](https://libgdx.com/) as a backend.
-
-This is the `core` part of the project. It contains the actual framework without any launcher implementation. You can use it to develop your own game, but it is probably easier to use the [dungeon-starter](https://github.com/PM-Dungeon/dungeon-starter) project as a starting point for your own game.
 
 ## Requirements
 
@@ -16,8 +15,8 @@ This is the `core` part of the project. It contains the actual framework without
 
 To create your own game using the PM-Dungeon framework, check out the quick start guide:
 
-- [German](https://github.com/PM-Dungeon/dungeon-starter/blob/master/documentation/quickstart_de.md)
-- [English](https://github.com/PM-Dungeon/dungeon-starter/blob/master/documentation/quickstart_en.md)
+- [German]tbd
+- [English]tbd
 - [Javadoc](https://javadoc.io/doc/io.github.pm-dungeon/core/latest/index.html)
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Java CI](https://github.com/Programmiermethoden/pm-dungeon/actions/workflows/github_ci.yml/badge.svg)](https://github.com/Programmiermethoden/pm-dungeon/actions/workflows/github_ci.yml)
+[![Java CI](https://github.com/Programmiermethoden/PM-Dungeon/actions/workflows/github_ci.yml/badge.svg)](https://github.com/Programmiermethoden/PM-Dungeon/actions/workflows/github_ci.yml)
 
 # PM-Dungeon-Framework
 
@@ -17,7 +17,7 @@ To create your own game using the PM-Dungeon framework, check out the quick star
 
 - [German]tbd
 - [English]tbd
-- [Javadoc](https://javadoc.io/doc/io.github.pm-dungeon/core/latest/index.html)
+- [Javadoc](https://javadoc.io/doc/io.github.programmiermethoden/pm-dungeon/latest/index.html)
 
 ## Contributing
 

--- a/code/build.gradle
+++ b/code/build.gradle
@@ -12,8 +12,8 @@ plugins {
     id "org.owasp.dependencycheck" version "7.+"
 }
 
-group = "io.github.pm-dungeon"
-
+group = "io.github.programmiermethoden"
+version = System.getenv("BUILD_NUMBER") ?: "0"
 ext {
     // we can not use the + operator here
     gdxVersion = "1.10.1-SNAPSHOT"
@@ -115,7 +115,7 @@ java {
 publishing {
     publications {
         maven(MavenPublication) {
-            groupId = "io.github.pm-dungeon"
+            groupId = "io.github.programmiermethoden"
             artifactId = "pm-dungeon"
             version = project.version
 
@@ -123,12 +123,12 @@ publishing {
 
             pom {
                 name = "PM-Dungeon core"
-                description = "The pmdungeon is a lightweight, libgdx based, Java framework for the development of a 2D rogue like."
-                url = "https://github.com/Programmiermethoden/pm-dungeon"
+                description = "The PM-Dungeon is a lightweight Java framework for the development of a 2D-Rouge-like game. It is designed for educational purposes and is especially aimed at inexperienced Java developers."
+                url = "https://github.com/Programmiermethoden/PM-Dungeon"
                 licenses {
                     license {
                         name = "MIT License"
-                        url = "https://github.com/Programmiermethoden/pm-dungeon/blob/master/LICENSE.md"
+                        url = "https://github.com/Programmiermethoden/PM-Dungeon/blob/master/LICENSE.md"
                     }
                 }
                 developers {
@@ -149,9 +149,9 @@ publishing {
                     }
                 }
                 scm {
-                    connection = "scm:git:https://github.com/Programmiermethoden/pm-dungeon.git"
+                    connection = "scm:git:https://github.com/Programmiermethoden/PM-Dungeon.git"
                     developerConnection = ""
-                    url = "https://github.com/Programmiermethoden/pm-dungeon.git"
+                    url = "https://github.com/Programmiermethoden/PM-Dungeon.git"
                 }
             }
         }

--- a/code/build.gradle
+++ b/code/build.gradle
@@ -116,7 +116,7 @@ publishing {
     publications {
         maven(MavenPublication) {
             groupId = "io.github.pm-dungeon"
-            artifactId = "core"
+            artifactId = "pm-dungeon"
             version = project.version
 
             from components.java
@@ -124,11 +124,11 @@ publishing {
             pom {
                 name = "PM-Dungeon core"
                 description = "The pmdungeon is a lightweight, libgdx based, Java framework for the development of a 2D rogue like."
-                url = "https://github.com/PM-Dungeon/core"
+                url = "https://github.com/Programmiermethoden/pm-dungeon"
                 licenses {
                     license {
                         name = "MIT License"
-                        url = "https://github.com/PM-Dungeon/core/blob/master/LICENSE.md"
+                        url = "https://github.com/Programmiermethoden/pm-dungeon/blob/master/LICENSE.md"
                     }
                 }
                 developers {
@@ -149,9 +149,9 @@ publishing {
                     }
                 }
                 scm {
-                    connection = "scm:git:https://github.com/PM-Dungeon/core.git"
+                    connection = "scm:git:https://github.com/Programmiermethoden/pm-dungeon.git"
                     developerConnection = ""
-                    url = "https://github.com/PM-Dungeon/core"
+                    url = "https://github.com/Programmiermethoden/pm-dungeon.git"
                 }
             }
         }

--- a/code/build.gradle
+++ b/code/build.gradle
@@ -122,7 +122,7 @@ publishing {
             from components.java
 
             pom {
-                name = "PM-Dungeon core"
+                name = "PM-Dungeon"
                 description = "The PM-Dungeon is a lightweight Java framework for the development of a 2D-Rouge-like game. It is designed for educational purposes and is especially aimed at inexperienced Java developers."
                 url = "https://github.com/Programmiermethoden/PM-Dungeon"
                 licenses {


### PR DESCRIPTION
fixes #361 

- [x] Organisation umbenennen
- [x] Repository umbenennen
- [x] URLs im Buildscript angepasst
- [x] URLs im der Readme angepasst
- [x] URLs im Wiki angepasst 

@TGrothe @cagix Hab ich irgendwo was vergessen?
Die `group.id` habe ich NICHT geändert. So wie ich Tobi verstanden hatte, ist die irgendwo bei Mavencentral registriert und daher nicht so einfach austauschbar, richtig? 