### PR TITLE
[Toolchain] Re-rename groupID

### DIFF
--- a/.github/workflows/publish_github.yml
+++ b/.github/workflows/publish_github.yml
@@ -1,10 +1,12 @@
 name: Publish jar to GitHub
 on:
     release:
-        types: [ created ]
+        types: [ published ]
 jobs:
     publish-github:
         runs-on: ubuntu-latest
+        env:
+            BUILD_NUMBER: ${{ github.event.release.tag_name }}
         steps:
             -   name: Checkout action
                 uses: actions/checkout@v3

--- a/.github/workflows/publish_maven.yml
+++ b/.github/workflows/publish_maven.yml
@@ -1,7 +1,7 @@
 name: Publish package to the Maven Central Repository
 on:
     release:
-        types: [ created ]
+        types: [ published ]
 jobs:
     publish-maven:
         runs-on: ubuntu-latest
@@ -19,6 +19,7 @@ jobs:
                 run: ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository
                 working-directory: code
                 env:
+                    BUILD_NUMBER: ${{ github.event.release.tag_name }}
                     MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
                     MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
                     GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}

--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ The **PM-Dungeon** is a lightweight Java framework for the development of a 2D-R
 
 To create your own game using the PM-Dungeon framework, check out the quick start guide:
 
-- [German]tbd
-- [English]tbd
-- [Javadoc](https://javadoc.io/doc/io.github.programmiermethoden/pm-dungeon/latest/index.html)
+- [German] tbd
+- [English] tbd
+- [Javadoc](https://javadoc.io/doc/io.github.pm-dungeon/pm-dungeon/latest/index.html)
 
 ## Contributing
 

--- a/code/build.gradle
+++ b/code/build.gradle
@@ -12,7 +12,7 @@ plugins {
     id "org.owasp.dependencycheck" version "7.+"
 }
 
-group = "io.github.programmiermethoden"
+group = "io.github.pm-dungeon"
 version = System.getenv("BUILD_NUMBER") ?: "0"
 ext {
     // we can not use the + operator here
@@ -115,7 +115,7 @@ java {
 publishing {
     publications {
         maven(MavenPublication) {
-            groupId = "io.github.programmiermethoden"
+            groupId = "io.github.pm-dungeon"
             artifactId = "pm-dungeon"
             version = project.version
 


### PR DESCRIPTION
follow-up zu #361

Folgende Fehlermeldung bei 5.0.0:

```
* What went wrong:
Execution failed for task ':initializeSonatypeStagingRepository'.
> Failed to find staging profile for package group: io.github.programmiermethoden
```

Ich denke, die groupId sollten wir nicht ändern, damit diese mit dem staging profile übereinstimmt.